### PR TITLE
feature/add-mozilla-colors

### DIFF
--- a/generate-cdp-colors.js
+++ b/generate-cdp-colors.js
@@ -1,12 +1,20 @@
 const fs = require("fs");
 
 const COLORS = {
+  black: "#000000",
+  white: "#fff",
+  neon_blue: "#00ffff",
+  lemon_yellow: "#fff44f",
+  warm_red: "#ff4f5e",
+  neon_green: "#54ffbd",
+  dark_green: "#005e5e",
+  dark_blue: "#00458b",
+  dark_grey: "#959595",
   dark_purple: "#190d2e",
   light_purple: "#664ebc",
   red: "#ff3f57",
   dark_orange: "#ea5246",
   yellow: "#feb938",
-  white: "#fff",
   light_grey: "#f5f5f5",
   teal: "#03bdb8",
 };


### PR DESCRIPTION
Add some color Mozilla colors from https://mozilla.design/mozilla/color/.

I kept CDP version of  dark_purple and light_grey instead of changing them.